### PR TITLE
added missing http to source url for jquery

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     </nav>
 </div>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular-animate.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular-touch.min.js"></script>


### PR DESCRIPTION
On line 31 of index.html, the script source for jquery is missing 'https', and so jquery was not being loaded.

This is probably only a problem when we are running the files locally - the browser tries to load the url with a 'file' protocol- but I imagine that is how this tutorial code would be used.
